### PR TITLE
Fix several compile errors

### DIFF
--- a/src/intra.c
+++ b/src/intra.c
@@ -508,7 +508,7 @@ static void predict_cclm(
   int available_left_below = 0;
 
 
-  uvg_pixel *y_rec = lcu->rec.y + x_scu + y_scu * LCU_WIDTH;
+  const uvg_pixel *y_rec = lcu->rec.y + x_scu + y_scu * LCU_WIDTH;
   const int stride2 = (((state->tile->frame->width + 7) & ~7) + FRAME_PADDING_LUMA);
 
   // Essentially what this does is that it uses 6-tap filtering to downsample

--- a/src/search_inter.c
+++ b/src/search_inter.c
@@ -1204,7 +1204,7 @@ int uvg_get_skip_context(int x, int y, lcu_t* const lcu, cu_array_t* const cu_a,
 /**
 * \brief Calculate the scaled MV
 */
-static INLINE int16_t get_scaled_mv(int16_t mv, int scale)
+static INLINE int32_t get_scaled_mv(int16_t mv, int scale)
 {
   int32_t scaled = scale * mv;
   return CLIP(-131072, 131071, (scaled + 127 + (scaled < 0)) >> 8);


### PR DESCRIPTION
  src/search_inter.c:1210: implicit conversion from 'int' to 'int16_t' was truncating constants.
  src/intra.c:511: const qualifier discarded
