### PR TITLE
[10bit] don't overwrite heap

### DIFF
--- a/src/transform.c
+++ b/src/transform.c
@@ -570,14 +570,9 @@ void uvg_chroma_transform_search(
   enum uvg_tree_type tree_type)
 {
   ALIGNED(64) coeff_t u_coeff[LCU_WIDTH_C * LCU_WIDTH_C * 5];
+  ALIGNED(64) uvg_pixel u_recon[LCU_WIDTH_C * LCU_WIDTH_C * 5];
   ALIGNED(64) coeff_t v_coeff[LCU_WIDTH_C * LCU_WIDTH_C * 2]; // In case of JCCR the v channel does not have coefficients
-#if UVG_BIT_DEPTH == 8
-  ALIGNED(64) uint8_t u_recon[LCU_WIDTH_C * LCU_WIDTH_C * 5];
-  ALIGNED(64) uint8_t v_recon[LCU_WIDTH_C * LCU_WIDTH_C * 5];
-#else
-  ALIGNED(64) uint16_t u_recon[LCU_WIDTH_C * LCU_WIDTH_C * 5];
-  ALIGNED(64) uint16_t v_recon[LCU_WIDTH_C * LCU_WIDTH_C * 5];
-#endif
+  ALIGNED(64) uvg_pixel v_recon[LCU_WIDTH_C * LCU_WIDTH_C * 5];
   const int width  = cu_loc->chroma_width;
   const int height = cu_loc->chroma_height;
 

--- a/src/transform.c
+++ b/src/transform.c
@@ -570,9 +570,14 @@ void uvg_chroma_transform_search(
   enum uvg_tree_type tree_type)
 {
   ALIGNED(64) coeff_t u_coeff[LCU_WIDTH_C * LCU_WIDTH_C * 5];
-  ALIGNED(64) uint8_t u_recon[LCU_WIDTH_C * LCU_WIDTH_C * 5];
   ALIGNED(64) coeff_t v_coeff[LCU_WIDTH_C * LCU_WIDTH_C * 2]; // In case of JCCR the v channel does not have coefficients
+#if UVG_BIT_DEPTH == 8
+  ALIGNED(64) uint8_t u_recon[LCU_WIDTH_C * LCU_WIDTH_C * 5];
   ALIGNED(64) uint8_t v_recon[LCU_WIDTH_C * LCU_WIDTH_C * 5];
+#else
+  ALIGNED(64) uint16_t u_recon[LCU_WIDTH_C * LCU_WIDTH_C * 5];
+  ALIGNED(64) uint16_t v_recon[LCU_WIDTH_C * LCU_WIDTH_C * 5];
+#endif
   const int width  = cu_loc->chroma_width;
   const int height = cu_loc->chroma_height;
 


### PR DESCRIPTION
```
transform.c: In function 'uvg_chroma_transform_search':
transform.c:717:31: warning: passing argument 2 of 'uvg_pixels_blit' from incompatible pointer type [-Wincompatible-pointer-types]
  717 |       uvg_pixels_blit(u_pred, &u_recon[trans_offset * i], width, height, width, width);
      |                               ^~~~~~~~~~~~~~~~~~~~~~~~~~
      |                               |
      |                               uint8_t * {aka unsigned char *}
In file included from cu.h:42,
                 from transform.h:41,
                 from transform.c:33:
image.h:118:56: note: expected 'uvg_pixel *' {aka 'short unsigned int *'} but argument is of type 'uint8_t *' {aka 'unsigned char *'}
  118 | void uvg_pixels_blit(const uvg_pixel* orig, uvg_pixel *dst,
      |                                             ~~~~~~~~~~~^~~
transform.c:758:31: warning: passing argument 2 of 'uvg_pixels_blit' from incompatible pointer type [-Wincompatible-pointer-types]
  758 |       uvg_pixels_blit(v_pred, &v_recon[trans_offset * i], width, height, width, width);
      |                               ^~~~~~~~~~~~~~~~~~~~~~~~~~
      |                               |
      |                               uint8_t * {aka unsigned char *}
In file included from cu.h:42,
                 from transform.h:41,
                 from transform.c:33:
image.h:118:56: note: expected 'uvg_pixel *' {aka 'short unsigned int *'} but argument is of type 'uint8_t *' {aka 'unsigned char *'}
  118 | void uvg_pixels_blit(const uvg_pixel* orig, uvg_pixel *dst,
      |                                             ~~~~~~~~~~~^~~
transform.c:762:56: warning: passing argument 2 of 'uvg_pixels_calc_ssd' from incompatible pointer type [-Wincompatible-pointer-types]
  762 |       ssd_u = uvg_pixels_calc_ssd(&lcu->ref.u[offset], &u_recon[trans_offset * i],
      |                                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                        |
      |                                                        uint8_t * {aka unsigned char *}
transform.c:762:56: note: expected 'const uvg_pixel * const' {aka 'const short unsigned int * const'} but argument is of type 'uint8_t *' {aka 'unsigned char *'}
transform.c:765:56: warning: passing argument 2 of 'uvg_pixels_calc_ssd' from incompatible pointer type [-Wincompatible-pointer-types]
  765 |       ssd_v = uvg_pixels_calc_ssd(&lcu->ref.v[offset], &v_recon[trans_offset * i],
      |                                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                        |
      |                                                        uint8_t * {aka unsigned char *}
transform.c:765:56: note: expected 'const uvg_pixel * const' {aka 'const short unsigned int * const'} but argument is of type 'uint8_t *' {aka 'unsigned char *'}
```