### PR TITLE
Added support to disable AVX2 instructions.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,12 @@ include(GNUInstallDirs) #Helps to define correct distro specific install directo
 include(CheckCSourceCompiles)
 
 if(ENABLE_AVX2)
+  if(MSVC)
+    set(CMAKE_REQUIRED_FLAGS "/arch:AVX2")
+  else()
+    set(CMAKE_REQUIRED_FLAGS "-mavx2")
+  endif()
+
   check_c_source_compiles("
     #include <immintrin.h>
     int main() {
@@ -195,11 +201,15 @@ set_target_properties(uvg266-bin PROPERTIES RUNTIME_OUTPUT_NAME uvg266)
 
 if(MSVC)
   target_include_directories(uvg266 PUBLIC src/threadwrapper/include)
-  set_property( SOURCE ${LIB_SOURCES_STRATEGIES_AVX2} APPEND PROPERTY COMPILE_FLAGS "/arch:AVX2" )
+  if(ENABLE_AVX2)
+    set_property( SOURCE ${LIB_SOURCES_STRATEGIES_AVX2} APPEND PROPERTY COMPILE_FLAGS "/arch:AVX2" )
+  endif()
 else()
   list(APPEND ALLOW_AVX2 "x86_64" "AMD64")
-  if(ENABLE_AVX2 AND ${CMAKE_SYSTEM_PROCESSOR} IN_LIST ALLOW_AVX2)
-    set_property( SOURCE ${LIB_SOURCES_STRATEGIES_AVX2} APPEND PROPERTY COMPILE_FLAGS "-mavx2 -mbmi -mpopcnt -mlzcnt -mbmi2" )
+  if(${CMAKE_SYSTEM_PROCESSOR} IN_LIST ALLOW_AVX2)
+    if(ENABLE_AVX2)
+      set_property( SOURCE ${LIB_SOURCES_STRATEGIES_AVX2} APPEND PROPERTY COMPILE_FLAGS "-mavx2 -mbmi -mpopcnt -mlzcnt -mbmi2" )
+    endif()
     set_property( SOURCE ${LIB_SOURCES_STRATEGIES_SSE41} APPEND PROPERTY COMPILE_FLAGS "-msse4.1" )
     set_property( SOURCE ${LIB_SOURCES_STRATEGIES_SSE42} APPEND PROPERTY COMPILE_FLAGS "-msse4.2" )
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ if(ENABLE_AVX2)
   else()
     message(STATUS "AVX2 is supported.")
   endif()
+  unset(CMAKE_REQUIRED_FLAGS)
 endif()
 
 set(UVG266_INSTALL_LIBDIR "${CMAKE_INSTALL_LIBDIR}" CACHE PATH "uvg266 library install path")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@ VERSION 0.8.1 )
 
 option(BUILD_SHARED_LIBS "Build using shared uvg266 library" ON)
 
+option(ENABLE_AVX2 "Enable AVX2 optimizations" ON)
+
 option(BUILD_TESTS "Build tests" ON)
 
 include(GNUInstallDirs) #Helps to define correct distro specific install directories
@@ -143,7 +145,12 @@ target_include_directories(uvg266 PUBLIC src)
 target_include_directories(uvg266 PUBLIC src/extras)
 target_include_directories(uvg266 PUBLIC src/strategies)
 
-file(GLOB LIB_SOURCES_STRATEGIES_AVX2 RELATIVE ${PROJECT_SOURCE_DIR} "src/strategies/avx2/*.c")
+if(ENABLE_AVX2)
+  file(GLOB LIB_SOURCES_STRATEGIES_AVX2 RELATIVE ${PROJECT_SOURCE_DIR} "src/strategies/avx2/*.c")
+else()
+  set(LIB_SOURCES_STRATEGIES_AVX2 "")
+endif()
+
 file(GLOB LIB_SOURCES_STRATEGIES_SSE41 RELATIVE ${PROJECT_SOURCE_DIR} "src/strategies/sse41/*.c")
 file(GLOB LIB_SOURCES_STRATEGIES_SSE42 RELATIVE ${PROJECT_SOURCE_DIR} "src/strategies/sse42/*.c")
 
@@ -174,7 +181,7 @@ if(MSVC)
   set_property( SOURCE ${LIB_SOURCES_STRATEGIES_AVX2} APPEND PROPERTY COMPILE_FLAGS "/arch:AVX2" )
 else()
   list(APPEND ALLOW_AVX2 "x86_64" "AMD64")
-  if(${CMAKE_SYSTEM_PROCESSOR} IN_LIST ALLOW_AVX2) 
+  if(ENABLE_AVX2 AND ${CMAKE_SYSTEM_PROCESSOR} IN_LIST ALLOW_AVX2)
     set_property( SOURCE ${LIB_SOURCES_STRATEGIES_AVX2} APPEND PROPERTY COMPILE_FLAGS "-mavx2 -mbmi -mpopcnt -mlzcnt -mbmi2" )
     set_property( SOURCE ${LIB_SOURCES_STRATEGIES_SSE41} APPEND PROPERTY COMPILE_FLAGS "-msse4.1" )
     set_property( SOURCE ${LIB_SOURCES_STRATEGIES_SSE42} APPEND PROPERTY COMPILE_FLAGS "-msse4.2" )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,23 @@ option(ENABLE_AVX2 "Enable AVX2 optimizations" ON)
 option(BUILD_TESTS "Build tests" ON)
 
 include(GNUInstallDirs) #Helps to define correct distro specific install directories
+include(CheckCSourceCompiles)
+
+if(ENABLE_AVX2)
+  check_c_source_compiles("
+    #include <immintrin.h>
+    int main() {
+      __m256i x = _mm256_set1_epi32(42);
+      return 0;
+    }" HAVE_AVX2)
+
+  if(NOT HAVE_AVX2)
+    message(WARNING "AVX2 not supported by the target CPU/compiler. Disabling AVX2.")
+    set(ENABLE_AVX2 OFF CACHE BOOL "Enable AVX2 optimizations" FORCE)
+  else()
+    message(STATUS "AVX2 is supported.")
+  endif()
+endif()
 
 set(UVG266_INSTALL_LIBDIR "${CMAKE_INSTALL_LIBDIR}" CACHE PATH "uvg266 library install path")
 set(UVG266_INSTALL_BINDIR "${CMAKE_INSTALL_BINDIR}" CACHE PATH "uvg266 binary install path")


### PR DESCRIPTION
Hello devs,

I just added support to disable AVX2 instructions on cmake since I was having trouble to build uvg266 on my legacy device. I hope it can help anyone who has a machine older than 2014-ish.

Regards,
Gabriel