### PR TITLE
[tests] Fix compilation error with GCC 15

### DIFF
--- a/tests/tests_main.c
+++ b/tests/tests_main.c
@@ -52,7 +52,7 @@ int main(int argc, char **argv)
 {
   GREATEST_MAIN_BEGIN();
 
-  init_test_strategies(1);
+  init_test_strategies();
 #if UVG_BIT_DEPTH == 8
   RUN_SUITE(sad_tests);
   RUN_SUITE(intra_sad_tests);


### PR DESCRIPTION
Specifically, gcc 15 tightened some rules and now errors on the use of `init_test_strategies(1);` as it is declared as
`void init_test_strategies();` with zero arguments.