### PR TITLE
Add RISC-V CPU target detection

### DIFF
--- a/cmake/checks/arch/have_riscv.c
+++ b/cmake/checks/arch/have_riscv.c
@@ -1,0 +1,7 @@
+#if defined(__riscv)
+
+int main() {
+  return 0;
+}
+
+#endif

--- a/cmake/checks/arch/have_riscv_64.c
+++ b/cmake/checks/arch/have_riscv_64.c
@@ -1,0 +1,7 @@
+#if defined(__riscv) && (__riscv_xlen == 64)
+
+int main() {
+  return 0;
+}
+
+#endif

--- a/cmake/cpu.cmake
+++ b/cmake/cpu.cmake
@@ -134,6 +134,18 @@ macro(uvg_maybe_enable_altivec)
 endmacro()
 
 ############################################################
+# RISC-V
+############################################################
+
+macro(uvg_check_have_riscv)
+  uvg_try_compile("${CMAKE_SOURCE_DIR}/cmake/checks/arch/have_riscv.c" "" UVG_HAVE_RISCV)
+endmacro()
+
+macro(uvg_check_have_riscv_64)
+  uvg_try_compile("${CMAKE_SOURCE_DIR}/cmake/checks/arch/have_riscv_64.c" "" UVG_HAVE_RISCV_64)
+endmacro()
+
+############################################################
 # Generic
 ############################################################
 
@@ -151,8 +163,13 @@ macro(uvg_detect_cpu_features)
   set(UVG_HAVE_POWERPC 0)
   set(UVG_HAVE_POWERPC_ALTIVEC 0)
 
+  set(UVG_HAVE_RISCV 0)
+  set(UVG_HAVE_RISCV_64 0)
+
   uvg_check_have_x86_64()
   uvg_check_have_powerpc()
+  uvg_check_have_riscv()
+  uvg_check_have_riscv_64()
 
   if(UVG_HAVE_X86_64)
     message(STATUS "Targeting x86-64")
@@ -163,5 +180,9 @@ macro(uvg_detect_cpu_features)
   elseif(UVG_HAVE_POWERPC)
     message(STATUS "Targeting PowerPC")
     uvg_maybe_enable_altivec()
+  elseif(UVG_HAVE_RISCV_64)
+    message(STATUS "Targeting RISC-V 64-bit")
+  elseif(UVG_HAVE_RISCV)
+    message(STATUS "Targeting RISC-V")
   endif()
 endmacro()

--- a/src/build_config.h.in
+++ b/src/build_config.h.in
@@ -46,6 +46,9 @@
 #define UVG_HAVE_POWERPC          @UVG_HAVE_POWERPC@
 #define UVG_HAVE_POWERPC_ALTIVEC  @UVG_HAVE_POWERPC_ALTIVEC@
 
+#define UVG_HAVE_RISCV            @UVG_HAVE_RISCV@
+#define UVG_HAVE_RISCV_64         @UVG_HAVE_RISCV_64@
+
 #define UVG_HAVE_X86_64           @UVG_HAVE_X86_64@
 #define UVG_HAVE_X86_64_MMX       0
 #define UVG_HAVE_X86_64_SSE       0

--- a/src/strategyselector.c
+++ b/src/strategyselector.c
@@ -598,5 +598,13 @@ static void set_hardware_flags(int32_t cpuid) {
   if (uvg_g_hardware_flags.powerpc_flags.altivec) fprintf(stderr, " AltiVec");
   fprintf(stderr, "\n");
 #endif
+
+#if UVG_HAVE_RISCV
+  fprintf(stderr, "Compiled: RISC-V");
+#if UVG_HAVE_RISCV_64
+  fprintf(stderr, " 64-bit");
+#endif
+  fprintf(stderr, ", flags:\nDetected: RISC-V, flags:\n");
+#endif
   
 }


### PR DESCRIPTION
## Why

uvg266 did not expose a dedicated RISC-V target in its generated build configuration, so riscv builds stayed implicit and target diagnostics were incomplete. This patch makes the baseline RISC-V path explicit while preserving the current generic implementation path.

## What changed

- Add CMake checks for `__riscv` and 64-bit RISC-V targets.
- Generate `UVG_HAVE_RISCV` and `UVG_HAVE_RISCV_64` in `build_config.h`.
- Report RISC-V in the runtime strategy selector diagnostics.
- Keep RISC-V on the existing generic C baseline path; this does not add RVV or other RISC-V SIMD kernels.

## Verification

- Ran native CMake configuration with Ninja, tests enabled, static library enabled, and shared library disabled.
- Built the native project successfully with `cmake --build build-codex-native --parallel`.
- Ran `ctest --test-dir build-codex-native --output-on-failure`; `Test_uvg266` passed.
- Ran a simulated `riscv64` CMake configuration using `__riscv=1` and `__riscv_xlen=64`; CMake reported `Targeting RISC-V 64-bit`.
- Checked the simulated `build_config.h`: `UVG_HAVE_RISCV=1`, `UVG_HAVE_RISCV_64=1`, and all x86/PowerPC SIMD feature macros were `0`.
- Checked the simulated Ninja source list; no `strategies/avx2`, `strategies/sse2`, `strategies/sse41`, `strategies/sse42`, or `strategies/altivec` sources were selected.

## Notes

This is a conservative portability patch. It makes the RISC-V target explicit while preserving the current generic implementation path. A real riscv64 cross-build or hardware run was not performed on the local Windows host because no RISC-V toolchain is available here.